### PR TITLE
Relax `delayed_job` version lock. Allow all 4.x versions.

### DIFF
--- a/logstasher.gemspec
+++ b/logstasher.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files lib`.split("\n")
 
   s.add_runtime_dependency 'logstash-event', '~> 1.2.0'
-  s.add_runtime_dependency 'delayed_job', '~> 4.0.2'
+  s.add_runtime_dependency 'delayed_job', '~> 4.0'
   s.add_runtime_dependency 'request_store'
   s.add_runtime_dependency 'activesupport', '>= 3.0'
   s.add_runtime_dependency 'activerecord', '>= 3.0'


### PR DESCRIPTION
Please see the `delayed_job` CHANGELOG below.
https://github.com/collectiveidea/delayed_job/blob/master/CHANGELOG.md

There do not appear to be breaking changes. If you'd prefer to be more conservative we could limit `delayed_job` to 4.0.x and 4.1.x
```
s.add_runtime_dependency 'delayed_job',  '>= 4.0', '< 4.2'
```
